### PR TITLE
Python3 support

### DIFF
--- a/SES/__init__.py
+++ b/SES/__init__.py
@@ -10,7 +10,7 @@ __all__= [
   '__version__'
 ]
 
-import ses
+from . import ses
 
 def new(secret=None,*args,**kw):
   return ses.SES(secret,*args,**kw)

--- a/SES/ses.py
+++ b/SES/ses.py
@@ -93,7 +93,7 @@ def bitunpack(flds,bits):
 class SES(object):
 
   def __init__(self,secret,hashbits=80,expiration=10,fbits=2,chars=BASE,
-  	nservers=1,server=0,maxval=3):
+          nservers=1,server=0,maxval=3):
     if type(secret) == str:
       self.secret = (secret,)
     else:
@@ -204,16 +204,16 @@ with an old secret."""
     for s in secret:
       h = hmac.new(s,'',sha)
       for i in data:
-	h.update(i)
+        h.update(i)
       if hash == longbits(h.digest(),self.hashbits):
         return True
     return False;
 
   def sig_create(self,msgid,ts,h):
     """Return encoded signature.
-    	msgid - long integer id unique for timecode
-    	ts    - 32 bit timecode: day fractions since epoch
-	h     - long with high order self.hashbits bits of hash digest"""
+       msgid - long integer id unique for timecode
+       ts    - 32 bit timecode: day fractions since epoch
+       h     - long with high order self.hashbits bits of hash digest"""
     if ts:
       return self.encode(bitpack(self.flds,msgid,ts % self.tcmask,h))
     else:
@@ -221,22 +221,22 @@ with an old secret."""
 
   def sig_extract(self,sig,ts):
     """Return msgid,timecode,hash extracted from sig.
-	sig - encoded sig returned by sig_create
-	ts  - the current timecode
+       sig - encoded sig returned by sig_create
+       ts  - the current timecode
     """
     msgid,tc,hash = bitunpack(self.flds,self.decode(sig))
     tcmask = self.tcmask
     if tc != tcmask:
       tc = ts // tcmask * tcmask + int(tc)
       if tc > ts:
-	tc -= tcmask
+        tc -= tcmask
     else:
       tc = 0
     return msgid,tc,hash
    
   def sign(self,address,msgid=None):
     """Return signed address.
-	if msgid is supplied, a fixed signature is generated."""
+       if msgid is supplied, a fixed signature is generated."""
     local,domain = address.split('@',1)
     if msgid:	# fixed sig
       ts = 0
@@ -251,19 +251,19 @@ with an old secret."""
     unchanged if signature is invalid."""
     if address.upper().startswith('SES='):
       try:
-	local,domain = address.split('@',1)
-	tag,sig,user = local.split('=')
+        local,domain = address.split('@',1)
+        tag,sig,user = local.split('=')
       except ValueError:
-	raise ValueError("Invalid SES signature format: %s" % local)
+        raise ValueError("Invalid SES signature format: %s" % local)
       ts = self.get_timecode()
       msgid,tc,h = self.sig_extract(sig,ts)
       if not tc or ts - tc < self.expiration and self.hash_verify(h,
-      	struct.pack('>QQ',tc,msgid),user,'@',domain.lower()):
-	if tc:	# count validations
-	  self.valtrack[msgid] = cnt = self.valtrack.get(msgid,0) + 1
-	  if cnt > self.maxval:
-	    raise RuntimeError(
-	      "Too many validations of signature: %s" % address)
+              struct.pack('>QQ',tc,msgid),user,'@',domain.lower()):
+        if tc:	# count validations
+          self.valtrack[msgid] = cnt = self.valtrack.get(msgid,0) + 1
+          if cnt > self.maxval:
+            raise RuntimeError(
+              "Too many validations of signature: %s" % address)
         return user + '@' + domain,tc,msgid
     return address,
 

--- a/SES/ses.py
+++ b/SES/ses.py
@@ -53,7 +53,7 @@ BASE='ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'
 def longbits(hash,n):
   "Return leading n bits of hash digest converted to long."
   hashbits = 0
-  h = 0L
+  h = 0
   for b in hash:
     h = (h << 8) + ord(b)
     hashbits += 8
@@ -62,7 +62,7 @@ def longbits(hash,n):
   return h
 
 def bitpack(flds,*data):
-  bits = 0L
+  bits = 0
   for n,v in zip(flds,data):
     bits = (bits << n) | v
   return bits
@@ -72,7 +72,7 @@ def bitunpack(flds,bits):
   f = list(flds[1:])
   f.reverse()
   for n in f:
-    mask = (1L << n) - 1
+    mask = (1 << n) - 1
     a.insert(0,bits & mask)
     bits >>= n
   a.insert(0,bits)
@@ -100,7 +100,7 @@ class SES(object):
       self.secret = secret
     self.hashbits = hashbits
     self.chars = chars
-    self.last_id = 0L
+    self.last_id = 0
     self.frac_day = DAY >> fbits
     self.last_ts = int(time.time() / self.frac_day)
     tsbits = 1
@@ -125,7 +125,7 @@ class SES(object):
     return int(s / self.frac_day)
 
   def warn(self,*msg):
-    print >>sys.stderr,'WARNING:',' '.join(msg)
+    print('WARNING:',' '.join(msg), file=sys.stderr)
 
   def set_secret(self,*args):
     """ses.set_secret(new,old,...)
@@ -146,7 +146,7 @@ secrets are tried to see if the hash can be validated. Don't use "foo",
     if ts == self.last_ts:	# if still same fractional day
       msgid = self.last_id + 1	#   assign next sequential id
     else:
-      msgid = 1L
+      msgid = 1
     self.last_ts,self.last_id = ts,msgid
     return ts,msgid * self.nservers + self.server
 
@@ -272,8 +272,8 @@ if __name__ == '__main__':
   ses = SES('shhhh!')
   for a in sys.argv[1:]:
     if a.startswith('-m'):
-      ses.last_id = long(a[2:])
+      ses.last_id = int(a[2:])
     elif a.startswith('SES'):
-      print ses.verify(a)
+      print(ses.verify(a))
     else:
-      print ses.sign(a)
+      print(ses.sign(a))

--- a/SES/testses.py
+++ b/SES/testses.py
@@ -24,10 +24,10 @@ class SESTestCase(unittest.TestCase):
       self.assertEqual(tc,self.ses.get_timecode(secs))
 
   def testHash(self):
-    data = ('now','is','the','time')
+    data = (b'now', b'is', b'the', b'time')
     h = self.ses.hash_create(*data)
     self.assertTrue(self.ses.hash_verify(h,*data))
-    self.assertTrue(not self.ses.hash_verify(h,'some','other','data'))
+    self.assertTrue(not self.ses.hash_verify(h, b'some', b'other', b'data'))
 
   def testMessageID(self):
     while True:
@@ -44,7 +44,7 @@ class SESTestCase(unittest.TestCase):
 
   def testSigpack(self):
     tc = 50000
-    h = self.ses.hash_create('some','data')
+    h = self.ses.hash_create(b'some',b'data')
     for msgid in (1,100000,12345657423784):
       sig = self.ses.sig_create(msgid,tc,h)
       ts = tc + 30

--- a/SES/testses.py
+++ b/SES/testses.py
@@ -4,7 +4,7 @@
 # it under the same terms as Python itself.
 #
 import unittest
-import ses
+from . import ses
 import time
 
 class SESTestCase(unittest.TestCase):
@@ -13,7 +13,7 @@ class SESTestCase(unittest.TestCase):
     self.ses = ses.SES('shhh!')
 
   def testEncode(self):
-    for bits in (0L,1L,1234L,123738493059846347859040389523479L):
+    for bits in (0,1,1234,123738493059846347859040389523479):
       s = self.ses.encode(bits)
       self.assertEqual(bits,self.ses.decode(s))
 
@@ -26,8 +26,8 @@ class SESTestCase(unittest.TestCase):
   def testHash(self):
     data = ('now','is','the','time')
     h = self.ses.hash_create(*data)
-    self.failUnless(self.ses.hash_verify(h,*data))
-    self.failUnless(not self.ses.hash_verify(h,'some','other','data'))
+    self.assertTrue(self.ses.hash_verify(h,*data))
+    self.assertTrue(not self.ses.hash_verify(h,'some','other','data'))
 
   def testMessageID(self):
     while True:
@@ -45,19 +45,19 @@ class SESTestCase(unittest.TestCase):
   def testSigpack(self):
     tc = 50000
     h = self.ses.hash_create('some','data')
-    for msgid in (1L,100000L,12345657423784L):
+    for msgid in (1,100000,12345657423784):
       sig = self.ses.sig_create(msgid,tc,h)
       ts = tc + 30
       msgid2,tc2,h2 = self.ses.sig_extract(sig,ts)
-      self.failUnless(tc2 <= ts)
+      self.assertTrue(tc2 <= ts)
       self.assertEqual(msgid,msgid2)
       self.assertEqual(tc,tc2)
       self.assertEqual(h,h2)
       ts = tc + 200
       msgid2,tc2,h2 = self.ses.sig_extract(sig,ts)
-      self.failUnless(tc2 <= ts)
+      self.assertTrue(tc2 <= ts)
       self.assertEqual(msgid,msgid2)
-      self.failIfEqual(tc,tc2)
+      self.assertNotEqual(tc,tc2)
       self.assertEqual(h,h2)
 
   def get_timecode(self):
@@ -69,8 +69,8 @@ class SESTestCase(unittest.TestCase):
     self.timecode = 60000
     a = 'mickey@Mouse.com'
     sig = self.ses.sign(a)
-    self.failUnless(sig.endswith(a))
-    self.failUnless(sig.startswith('SES='))
+    self.assertTrue(sig.endswith(a))
+    self.assertTrue(sig.startswith('SES='))
     res = self.ses.verify(sig)
     self.assertEqual(res,(a,self.timecode,self.ses.last_id))
     res2 = self.ses.verify(sig.lower())
@@ -97,7 +97,7 @@ class SESTestCase(unittest.TestCase):
     sig2 = self.ses.sign(a)
     self.assertNotEqual(sig,sig2)
     # but passing a msgid generates a fixed sig
-    msgid = 12345678L
+    msgid = 12345678
     sig = self.ses.sign(a,msgid)
     sig2 = self.ses.sign(a,msgid)
     self.assertEqual(sig,sig2)

--- a/SRS/Base.py
+++ b/SRS/Base.py
@@ -82,9 +82,9 @@ def parse_addr(sender):
 
 class Base(object):
   def __init__(self,secret=None,maxage=SRS.SRSMAXAGE,
-  	hashlength=SRS.SRSHASHLENGTH,
-	hashmin=None,separator='=',alwaysrewrite=False,ignoretimestamp=False,
-	allowunsafesrs=False):
+        hashlength=SRS.SRSHASHLENGTH,
+        hashmin=None,separator='=',alwaysrewrite=False,ignoretimestamp=False,
+        allowunsafesrs=False):
     if type(secret) == str:
       self.secret = (secret,)
     else:
@@ -263,7 +263,7 @@ with an old secret."""
     for s in secret:
       h = hmac.new(s,'',sha)
       for i in data:
-	h.update(i.lower())
+        h.update(i.lower())
       valid = base64.encodestring(h.digest())[:len(hash)]
       # We test all case sensitive matches before case insensitive
       # matches. While the risk of a case insensitive collision is
@@ -273,9 +273,9 @@ with an old secret."""
     hash = hash.lower()
     for h in hashes:
       if hash == h.lower():
-	self.warn("""SRS: Case insensitive hash match detected.
+        self.warn("""SRS: Case insensitive hash match detected.
 Someone smashed case in the local-part.""")
-	return True
+        return True
     return False;
 
   def set_secret(self,*args):

--- a/SRS/Base.py
+++ b/SRS/Base.py
@@ -36,6 +36,8 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the same terms as Python itself.
 
+from __future__ import print_function
+
 import time
 import hmac
 try: from hashlib import sha1 as sha

--- a/SRS/Base.py
+++ b/SRS/Base.py
@@ -244,7 +244,7 @@ and there may be collision problems with sender addresses)."""
 
     secret = self.get_secret()
     assert secret, "Cannot create a cryptographic MAC without a secret"
-    h = hmac.new(secret[0],'',sha)
+    h = hmac.new(secret[0].encode(),b'',sha)
     for i in data:
       h.update(i.lower())
     hash = base64.encodestring(h.digest())
@@ -263,7 +263,7 @@ with an old secret."""
     assert secret, "Cannot create a cryptographic MAC without a secret"
     hashes = []
     for s in secret:
-      h = hmac.new(s,'',sha)
+      h = hmac.new(s.encode(),b'',sha)
       for i in data:
         h.update(i.lower())
       valid = base64.encodestring(h.digest())[:len(hash)]

--- a/SRS/Base.py
+++ b/SRS/Base.py
@@ -104,7 +104,7 @@ class Base(object):
     #self.ses0re = re.compile(r'^%s[-+=]' % SRS.SES0TAG,re.IGNORECASE)
 
   def warn(self,*msg):
-    print >>sys.stderr,'WARNING: ',' '.join(msg)
+    print('WARNING: ',' '.join(msg), file=sys.stderr)
 
   def sign(self,sender):
     """srsaddress = srs.sign(sender)

--- a/SRS/DB.py
+++ b/SRS/DB.py
@@ -24,8 +24,8 @@
 import bsddb
 import time
 import SRS
-from Base import Base
-from cPickle import dumps, loads
+from .Base import Base
+from pickle import dumps, loads
 
 class DB(Base):
   """A MLDBM based Sender Rewriting Scheme

--- a/SRS/DB.py
+++ b/SRS/DB.py
@@ -32,8 +32,8 @@ class DB(Base):
 
 SYNOPSIS
 
-	from SRS.DB import DB
-	srs = DB(Database='/var/run/srs.db', ...)
+        from SRS.DB import DB
+        srs = DB(Database='/var/run/srs.db', ...)
 
 DESCRIPTION
 

--- a/SRS/DB.py
+++ b/SRS/DB.py
@@ -21,7 +21,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the same terms as Python itself.
 
-import bsddb
+import bsddb3
 import time
 import SRS
 from .Base import Base
@@ -53,7 +53,7 @@ The database is not garbage collected."""
   def __init__(self,database='/var/run/srs.db',hashlength=24,*args,**kw):
     Base.__init__(self,hashlength=hashlength,*args,**kw)
     assert database, "No database specified for SRS.DB"
-    self.dbm = bsddb.btopen(database,'c')
+    self.dbm = bsddb3.btopen(database,'c')
 
   def compile(self,sendhost,senduser,srshost=None):
     ts = time.time()

--- a/SRS/DB.py
+++ b/SRS/DB.py
@@ -61,24 +61,24 @@ The database is not garbage collected."""
     data = dumps((ts,sendhost,senduser))
 
     # We rely on not getting collisions in this hash.
-    hash = self.hash_create(sendhost,senduser)
+    hash = self.hash_create(sendhost.encode(),senduser.encode())
 
     self.dbm[hash] = data
 
     # Note that there are 4 fields here and that sendhost may
     # not contain a + sign. Therefore, we do not need to escape
     # + signs anywhere in order to reverse this transformation.
-    return SRS.SRS0TAG + self.separator + hash
+    return SRS.SRS0TAG + self.separator + hash.decode()
 
   def parse(self,user,srshost=None):
     user,m = self.srs0re.subn('',user,1)
     assert m, "Reverse address does not match %s." % self.srs0re.pattern
 
     hash = user
-    data = self.dbm[hash]
+    data = self.dbm[hash.encode()]
     ts,sendhost,senduser = loads(data)
 
-    assert self.hash_verify(hash,sendhost,senduser), "Invalid hash"
+    assert self.hash_verify(hash.encode(),sendhost.encode(),senduser.encode()), "Invalid hash"
 
     assert self.time_check(ts), "Invalid timestamp"
 

--- a/SRS/Daemon.py
+++ b/SRS/Daemon.py
@@ -25,14 +25,14 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the same terms as Python itself.
 
-from Guarded import Guarded
+from .Guarded import Guarded
 import os
 import os.path
-import SocketServer
+import socketserver
 
 SRSSOCKET = '/tmp/srsd';
 
-class EximHandler(SocketServer.StreamRequestHandler):
+class EximHandler(socketserver.StreamRequestHandler):
 
   def handle(self):
     srs = self.server.srs
@@ -48,7 +48,7 @@ class EximHandler(SocketServer.StreamRequestHandler):
 	res = srs.reverse(*args)
       else:
 	raise ValueError("Invalid command %s" % cmd)
-    except Exception,x:
+    except Exception as x:
       res = "ERROR: %s"%x
     self.wfile.write(res+'\n')
 
@@ -81,7 +81,7 @@ and ensure the secret file is not empty."""
       os.unlink(socket)
     except:
       pass
-    self.server = SocketServer.UnixStreamServer(socket,EximHandler)
+    self.server = socketserver.UnixStreamServer(socket,EximHandler)
     self.server.srs = self.srs
 
   def run(self):

--- a/SRS/Daemon.py
+++ b/SRS/Daemon.py
@@ -39,8 +39,8 @@ class EximHandler(socketserver.StreamRequestHandler):
     sock = self.rfile
     try:
       line = self.rfile.readline()
-      #print "Read '%s' on %s\n" % (line.strip(),self.request)
-      args = line.split()
+      # print("Read '%s' on %s\n" % (line.strip(),self.request))
+      args = line.decode().split()
       cmd = args.pop(0).upper()
       if cmd == 'FORWARD':
         res = srs.forward(*args)
@@ -50,7 +50,7 @@ class EximHandler(socketserver.StreamRequestHandler):
         raise ValueError("Invalid command %s" % cmd)
     except Exception as x:
       res = "ERROR: %s"%x
-    self.wfile.write(res+'\n')
+    self.wfile.write((res+'\n').encode())
 
 
 class Daemon(object):

--- a/SRS/Daemon.py
+++ b/SRS/Daemon.py
@@ -43,11 +43,11 @@ class EximHandler(socketserver.StreamRequestHandler):
       args = line.split()
       cmd = args.pop(0).upper()
       if cmd == 'FORWARD':
-	res = srs.forward(*args)
+        res = srs.forward(*args)
       elif cmd == 'REVERSE':
-	res = srs.reverse(*args)
+        res = srs.reverse(*args)
       else:
-	raise ValueError("Invalid command %s" % cmd)
+        raise ValueError("Invalid command %s" % cmd)
     except Exception as x:
       res = "ERROR: %s"%x
     self.wfile.write(res+'\n')
@@ -60,12 +60,12 @@ class Daemon(object):
     if secret: secrets += secret
     if secretfile and os.path.exists(secretfile):
       assert os.path.isfile(secretfile) and os.access(secretfile,os.R_OK), \
-	"Secret file $secretfile not readable"
+        "Secret file $secretfile not readable"
       FH = open(secretfile)
       for ln in FH:
         if not ln: continue
-	if ln.startswith('#'): continue
-	secrets += ln
+        if ln.startswith('#'): continue
+        secrets += ln
       FH.close()
 
     assert secrets, \

--- a/SRS/Guarded.py
+++ b/SRS/Guarded.py
@@ -23,7 +23,7 @@
 
 import re
 import SRS
-from Shortcut import Shortcut
+from .Shortcut import Shortcut
 
 class Guarded(Shortcut):
   """This is the default subclass of SRS. An instance of this subclass

--- a/SRS/Guarded.py
+++ b/SRS/Guarded.py
@@ -63,15 +63,15 @@ without store, and guards against gaming the shortcut system."""
       # hash, srshost, srsuser
       undef,srshost,srsuser = senduser.split(SRS.SRSSEP,2)
 
-      hash = self.hash_create(srshost,srsuser)
+      hash = self.hash_create(srshost.encode(),srsuser.encode())
       return SRS.SRS1TAG + self.separator + \
-                SRS.SRSSEP.join((hash,srshost,srsuser))
+                SRS.SRSSEP.join((hash.decode(),srshost,srsuser))
 
     senduser,m = self.srs0rek.subn('',senduser,1)
     if m:
-      hash = self.hash_create(sendhost, senduser)
+      hash = self.hash_create(sendhost.encode(), senduser.encode())
       return SRS.SRS1TAG + self.separator + \
-                SRS.SRSSEP.join((hash,sendhost,senduser))
+                SRS.SRSSEP.join((hash.decode(),sendhost,senduser))
 
     return Shortcut.compile(self,sendhost,senduser,srshost=srshost)
 
@@ -87,7 +87,7 @@ without store, and guards against gaming the shortcut system."""
         srshost = hash
       else:
         assert srshost and srsuser, "Invalid SRS1 address"
-        assert self.hash_verify(hash,srshost,srsuser), "Invalid hash"
+        assert self.hash_verify(hash.encode(),srshost.encode(),srsuser.encode()), "Invalid hash"
       return srshost, SRS.SRS0TAG + srsuser
 
     return Shortcut.parse(self,user,srshost=srshost)

--- a/SRS/Guarded.py
+++ b/SRS/Guarded.py
@@ -65,13 +65,13 @@ without store, and guards against gaming the shortcut system."""
 
       hash = self.hash_create(srshost,srsuser)
       return SRS.SRS1TAG + self.separator + \
-		SRS.SRSSEP.join((hash,srshost,srsuser))
+                SRS.SRSSEP.join((hash,srshost,srsuser))
 
     senduser,m = self.srs0rek.subn('',senduser,1)
     if m:
       hash = self.hash_create(sendhost, senduser)
       return SRS.SRS1TAG + self.separator + \
-		SRS.SRSSEP.join((hash,sendhost,senduser))
+                SRS.SRSSEP.join((hash,sendhost,senduser))
 
     return Shortcut.compile(self,sendhost,senduser,srshost=srshost)
 
@@ -81,13 +81,13 @@ without store, and guards against gaming the shortcut system."""
       hash,srshost,srsuser = user.split(SRS.SRSSEP, 2)[-3:]
       if hash.find('.') >= 0:
         assert self.allowunsafesrs, \
-	  "Hashless SRS1 address received when AllowUnsafeSrs is not set"
-	# Reconstruct the parameters as they were in the old format.
-	srsuser = srshost + SRS.SRSSEP + srsuser
-	srshost = hash
+          "Hashless SRS1 address received when AllowUnsafeSrs is not set"
+        # Reconstruct the parameters as they were in the old format.
+        srsuser = srshost + SRS.SRSSEP + srsuser
+        srshost = hash
       else:
-	assert srshost and srsuser, "Invalid SRS1 address"
-	assert self.hash_verify(hash,srshost,srsuser), "Invalid hash"
+        assert srshost and srsuser, "Invalid SRS1 address"
+        assert self.hash_verify(hash,srshost,srsuser), "Invalid hash"
       return srshost, SRS.SRS0TAG + srsuser
 
     return Shortcut.parse(self,user,srshost=srshost)

--- a/SRS/Reversible.py
+++ b/SRS/Reversible.py
@@ -43,4 +43,4 @@ without store."""
     # not contain a + sign. Therefore, we do not need to escape
     # + signs anywhere in order to reverse this transformation.
     return SRS.SRS0TAG + self.separator + \
-	SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))
+        SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))

--- a/SRS/Reversible.py
+++ b/SRS/Reversible.py
@@ -36,11 +36,11 @@ without store."""
     timestamp = self.timestamp_create()
     # This has to be done in compile, because we might need access
     # to it for storing in a database.
-    hash = self.hash_create(timestamp,sendhost,senduser)
+    hash = self.hash_create(timestamp.encode(),sendhost.encode(),senduser.encode())
     if sendhost == srshost:
       sendhost = ''
     # Note that there are 4 fields here and that sendhost may
     # not contain a + sign. Therefore, we do not need to escape
     # + signs anywhere in order to reverse this transformation.
     return SRS.SRS0TAG + self.separator + \
-        SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))
+        SRS.SRSSEP.join((hash.decode(),timestamp,sendhost,senduser))

--- a/SRS/Reversible.py
+++ b/SRS/Reversible.py
@@ -22,7 +22,7 @@
 # it under the same terms as Python itself.
 
 import SRS
-from Shortcut import Shortcut
+from .Shortcut import Shortcut
 
 class Reversible(Shortcut):
 

--- a/SRS/Shortcut.py
+++ b/SRS/Shortcut.py
@@ -22,7 +22,7 @@
 # it under the same terms as Python itself.
 
 import SRS
-from Base import Base
+from .Base import Base
 
 class Shortcut(Base):
 

--- a/SRS/Shortcut.py
+++ b/SRS/Shortcut.py
@@ -67,7 +67,7 @@ without store, and shortcuts around all middleman resenders."""
 
     timestamp = self.timestamp_create()
 
-    hash = self.hash_create(timestamp, sendhost, senduser)
+    hash = self.hash_create(timestamp.encode(), sendhost.encode(), senduser.encode())
 
     if sendhost == srshost:
       sendhost = ''
@@ -76,7 +76,7 @@ without store, and shortcuts around all middleman resenders."""
     # escape separators anywhere in order to reverse this
     # transformation.
     return SRS.SRS0TAG + self.separator + \
-            SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))
+            SRS.SRSSEP.join((hash.decode(),timestamp,sendhost,senduser))
 
   def parse(self,user,srshost=None):
     user,m = self.srs0re.subn('',user,1)
@@ -89,7 +89,7 @@ without store, and shortcuts around all middleman resenders."""
     if not sendhost and srshost:
       sendhost = srshost
     # Again, this must match as above.
-    assert self.hash_verify(hash,timestamp,sendhost,senduser), "Invalid hash"
+    assert self.hash_verify(hash.encode(),timestamp.encode(),sendhost.encode(),senduser.encode()), "Invalid hash"
 
     assert self.timestamp_check(timestamp), "Invalid timestamp"
     return sendhost,senduser

--- a/SRS/Shortcut.py
+++ b/SRS/Shortcut.py
@@ -30,8 +30,8 @@ class Shortcut(Base):
 
 SYNOPSIS
 
-	import SRS.Shortcut
-	srs = SRS.Shortcut(...)
+        import SRS.Shortcut
+        srs = SRS.Shortcut(...)
 
 DESCRIPTION
 
@@ -60,10 +60,10 @@ without store, and shortcuts around all middleman resenders."""
     else:
       senduser,m = self.srs1re.subn('',senduser,1)
       if m:
-	# This should never be hit in practice. It would be bad.
-	# Introduce compatibility with the guarded format?
-	# SRSHOST, hash, timestamp, host, user
-	sendhost,senduser = senduser.split(SRS.SRSSEP,5)[-2:]
+        # This should never be hit in practice. It would be bad.
+        # Introduce compatibility with the guarded format?
+        # SRSHOST, hash, timestamp, host, user
+        sendhost,senduser = senduser.split(SRS.SRSSEP,5)[-2:]
 
     timestamp = self.timestamp_create()
 
@@ -76,7 +76,7 @@ without store, and shortcuts around all middleman resenders."""
     # escape separators anywhere in order to reverse this
     # transformation.
     return SRS.SRS0TAG + self.separator + \
-    	SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))
+            SRS.SRSSEP.join((hash,timestamp,sendhost,senduser))
 
   def parse(self,user,srshost=None):
     user,m = self.srs0re.subn('',user,1)

--- a/SRS/__init__.py
+++ b/SRS/__init__.py
@@ -42,7 +42,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the same terms as Python itself.
 
-__version__ = '0.30.12'
+__version__ = '1.0'
 
 __all__= [
   'Base',

--- a/SRS/__init__.py
+++ b/SRS/__init__.py
@@ -72,7 +72,7 @@ SRSMAXAGE = 21
 #from Reversible import Reversible
 #from Daemon import Daemon
 #from DB import DB
-import Guarded
+from . import Guarded
 
 def new(secret=None,*args,**kw):
   return Guarded.Guarded(secret,*args,**kw)

--- a/SocketMap.py
+++ b/SocketMap.py
@@ -5,14 +5,14 @@
 #
 # Base class for sendmail socket servers
 
-import SocketServer
+import socketserver
 
 class MapError(Exception):
   def __init__(self,code,reason):
     self.code = code
     self.reason = reason
 
-class Handler(SocketServer.StreamRequestHandler):
+class Handler(socketserver.StreamRequestHandler):
 
   def write(self,s):
     "write netstring to socket"
@@ -65,14 +65,14 @@ class Handler(SocketServer.StreamRequestHandler):
       except EOFError:
         #self.log("Ending connection")
 	return
-      except MapError,x:
+      except MapError as x:
 	if code in ('PERM','TIMEOUT','NOTFOUND','OK','TEMP'):
 	  self.write("%s %s"%(x.code,x.reason))
 	else:
 	  self.write("%s %s %s"%('PERM',x.code,x.reason))
-      except LookupError,x:
+      except LookupError as x:
         self.write("NOTFOUND")
-      except Exception,x:
+      except Exception as x:
 	#print x
 	self.write("TEMP %s"%x)
       # PERM,TIMEOUT
@@ -93,7 +93,7 @@ class Daemon(object):
     try:
       os.unlink(socket)
     except: pass
-    self.server = SocketServer.ThreadingUnixStreamServer(socket,handlerfactory)
+    self.server = socketserver.ThreadingUnixStreamServer(socket,handlerfactory)
     self.server.daemon = self
 
   def run(self):

--- a/SocketMap.py
+++ b/SocketMap.py
@@ -30,7 +30,7 @@ class Handler(socketserver.StreamRequestHandler):
       if not ch in "0123456789":
         raise ValueError
       if len(n) >= maxlen:
-	raise OverflowError
+        raise OverflowError
       n += ch
       ch = file.read(1)
     return int(n)
@@ -53,28 +53,28 @@ class Handler(socketserver.StreamRequestHandler):
     #self.log("connect")
     while True:
       try:
-	line = self.read()
-	self.log(line)
-	args = line.split(' ',1)
-	map = args.pop(0).replace('-','_')
-	meth = getattr(self, '_handle_' + map, None)
-	if not map:
-	  raise ValueError("Unrecognized map: %s" % map)
-	res = meth(*args)
-	self.write('OK ' + res)
+        line = self.read()
+        self.log(line)
+        args = line.split(' ',1)
+        map = args.pop(0).replace('-','_')
+        meth = getattr(self, '_handle_' + map, None)
+        if not map:
+          raise ValueError("Unrecognized map: %s" % map)
+        res = meth(*args)
+        self.write('OK ' + res)
       except EOFError:
         #self.log("Ending connection")
-	return
+        return
       except MapError as x:
-	if code in ('PERM','TIMEOUT','NOTFOUND','OK','TEMP'):
-	  self.write("%s %s"%(x.code,x.reason))
-	else:
-	  self.write("%s %s %s"%('PERM',x.code,x.reason))
+        if code in ('PERM','TIMEOUT','NOTFOUND','OK','TEMP'):
+          self.write("%s %s"%(x.code,x.reason))
+        else:
+          self.write("%s %s %s"%('PERM',x.code,x.reason))
       except LookupError as x:
         self.write("NOTFOUND")
       except Exception as x:
-	#print x
-	self.write("TEMP %s"%x)
+        #print x
+        self.write("TEMP %s"%x)
       # PERM,TIMEOUT
 
 # Application should subclass SocketMap.Daemon, and define

--- a/envfrom2srs.py
+++ b/envfrom2srs.py
@@ -11,7 +11,7 @@
 
 import SRS
 import re
-from ConfigParser import ConfigParser, DuplicateSectionError
+from configparser import ConfigParser, DuplicateSectionError
 
 # get SRS parameters from milter configuration
 cp = ConfigParser({
@@ -72,4 +72,4 @@ if __name__ == "__main__":
   sys.stderr.close()
   if len(sys.argv) > 2:
     fwdomain = sys.argv[-2]
-  print forward(sys.argv[-1])
+  print(forward(sys.argv[-1]))

--- a/pysrs.py
+++ b/pysrs.py
@@ -10,7 +10,7 @@ import SRS
 import SES
 import re
 import os
-from ConfigParser import ConfigParser, DuplicateSectionError
+from configparser import ConfigParser, DuplicateSectionError
 import SocketMap
 import time
 import sys
@@ -19,9 +19,9 @@ class SRSHandler(SocketMap.Handler):
 
   def log(self,*msg):
     # print "%s [%d]" % (time.strftime('%Y%b%d %H:%M:%S'),self.id),
-    print "%s" % (time.strftime('%Y%b%d %H:%M:%S'),),
-    for i in msg: print i,
-    print
+    print("%s" % (time.strftime('%Y%b%d %H:%M:%S'),), end=' ')
+    for i in msg: print(i, end=' ')
+    print()
     sys.stdout.flush()
 
   bracketRE = re.compile(r'[<>]')
@@ -154,10 +154,10 @@ def main(args):
     
   daemon.server.srs = srs
   daemon.server.ses = ses
-  print "%s pysrs startup" % time.strftime('%Y%b%d %H:%M:%S')
+  print("%s pysrs startup" % time.strftime('%Y%b%d %H:%M:%S'))
   sys.stdout.flush()
   daemon.run()
-  print "%s pysrs shutdown" % time.strftime('%Y%b%d %H:%M:%S')
+  print("%s pysrs shutdown" % time.strftime('%Y%b%d %H:%M:%S'))
 
 if __name__ == "__main__":
   main(sys.argv[1:])

--- a/pysrs.py
+++ b/pysrs.py
@@ -66,17 +66,17 @@ class SRSHandler(SocketMap.Handler):
       return old_address
     except:
       try:
-	senduser,sendhost = use_address.split('@')
-	shl = sendhost.lower()
-	if shl in sesdomain:
-	  new_address = ses.sign(use_address)
-	elif shl in signdomain:
-	  new_address = srs.sign(use_address)
-	else:
-	  new_address = srs.forward(use_address,fwdomain)
-	return new_address.replace('@','<@',1)+'.>'
+        senduser,sendhost = use_address.split('@')
+        shl = sendhost.lower()
+        if shl in sesdomain:
+          new_address = ses.sign(use_address)
+        elif shl in signdomain:
+          new_address = srs.sign(use_address)
+        else:
+          new_address = srs.forward(use_address,fwdomain)
+        return new_address.replace('@','<@',1)+'.>'
       except:
-	return old_address
+        return old_address
 
   def _handle_reverse_srs(self,old_address):
 
@@ -98,15 +98,15 @@ class SRSHandler(SocketMap.Handler):
         return a[0].replace('@','<@',1)+'.>'
       use_address = srs.reverse(use_address)
       while True:
-	try:
-	  use_address = srs.reverse(use_address)
-	except: break
+        try:
+          use_address = srs.reverse(use_address)
+        except: break
       return use_address.replace('@','<@',1)+'.>'
     except:
       if use_address.startswith('|'):
-	return '"%s"' % old_address
+        return '"%s"' % old_address
       else:
-	return old_address
+        return old_address
 
 def main(args):
 # get SRS parameters from milter configuration
@@ -144,13 +144,13 @@ def main(args):
   daemon.server.nosrsdomain = ()
   if cp.has_option('srs','ses'):
     daemon.server.sesdomain = [
-    	q.strip() for q in cp.get('srs','ses').split(',')]
+            q.strip() for q in cp.get('srs','ses').split(',')]
   if cp.has_option('srs','sign'):
     daemon.server.signdomain = [
-    	q.strip() for q in cp.get('srs','sign').split(',')]
+            q.strip() for q in cp.get('srs','sign').split(',')]
   if cp.has_option('srs','nosrs'):
     daemon.server.nosrsdomain = [
-    	q.strip() for q in cp.get('srs','nosrs').split(',')]
+            q.strip() for q in cp.get('srs','nosrs').split(',')]
     
   daemon.server.srs = srs
   daemon.server.ses = ses

--- a/setup.py
+++ b/setup.py
@@ -33,21 +33,21 @@ http://www.libsrs2.org/
         author = 'Stuart Gathman (Perl version by Shevek)', 
         author_email = 'stuart@bmsi.com',
         url = 'http://bmsi.com/python/pysrs.html',
-	py_modules = ['SocketMap'],
+        py_modules = ['SocketMap'],
         packages = ['SRS','SES'],
-	scripts = ['envfrom2srs.py','srs2envtol.py'],
-	keywords = ['SPF','SRS','SES'],
-	classifiers = [
-	  'Development Status :: 5 - Production/Stable',
-	  'Environment :: No Input/Output (Daemon)',
-	  'Intended Audience :: Developers',
-	  'Intended Audience :: System Administrators',
-	  'License :: OSI Approved :: Python License (CNRI Python License)',
-	  'Natural Language :: English',
-	  'Operating System :: OS Independent',
-	  'Programming Language :: Python',
-	  'Topic :: Communications :: Email',
-	  'Topic :: Communications :: Email :: Mail Transport Agents',
-	  'Topic :: Software Development :: Libraries :: Python Modules'
-	]
+        scripts = ['envfrom2srs.py','srs2envtol.py'],
+        keywords = ['SPF','SRS','SES'],
+        classifiers = [
+          'Development Status :: 5 - Production/Stable',
+          'Environment :: No Input/Output (Daemon)',
+          'Intended Audience :: Developers',
+          'Intended Audience :: System Administrators',
+          'License :: OSI Approved :: Python License (CNRI Python License)',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Topic :: Communications :: Email',
+          'Topic :: Communications :: Email :: Mail Transport Agents',
+          'Topic :: Software Development :: Libraries :: Python Modules'
+        ]
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         #-- Package description
         name = 'pysrs',
         license = 'Python license',
-        version = '0.30.12',
+        version = '1.0',
         description = 'Python SRS (Sender Rewriting Scheme) library',
         long_description = """Python SRS (Sender Rewriting Scheme) library.
 As SPF is implemented, MTAs that check SPF must account for any forwarders.

--- a/srs2envtol.py
+++ b/srs2envtol.py
@@ -50,7 +50,7 @@ def reverse(old_address):
     use_address = srs.reverse(use_address)
     while True:
       try:
-	use_address = srs.reverse(use_address)
+        use_address = srs.reverse(use_address)
       except: break
     return use_address.replace('@','<@',1)+'.>'
   except:

--- a/srs2envtol.py
+++ b/srs2envtol.py
@@ -11,7 +11,7 @@
 
 import SRS
 import re
-from ConfigParser import ConfigParser, DuplicateSectionError
+from configparser import ConfigParser, DuplicateSectionError
 
 # get SRS parameters from milter configuration
 cp = ConfigParser({
@@ -63,4 +63,4 @@ if __name__ == "__main__":
   import sys
   # No funny business in our output, please
   sys.stderr.close()
-  print reverse(sys.argv[1])
+  print(reverse(sys.argv[1]))

--- a/srsmilter.py
+++ b/srsmilter.py
@@ -110,17 +110,17 @@ class srsMilter(Milter.Base):
       return old_address
     except:
       try:
-	senduser,sendhost = use_address.split('@')
-	shl = sendhost.lower()
-	if shl in sesdomain:
-	  new_address = ses.sign(use_address)
-	elif shl in signdomain:
-	  new_address = srs.sign(use_address)
-	else:
-	  new_address = srs.forward(use_address,fwdomain)
-	return '<%s>'%new_address
+        senduser,sendhost = use_address.split('@')
+        shl = sendhost.lower()
+        if shl in sesdomain:
+          new_address = ses.sign(use_address)
+        elif shl in signdomain:
+          new_address = srs.sign(use_address)
+        else:
+          new_address = srs.forward(use_address,fwdomain)
+        return '<%s>'%new_address
       except:
-	return old_address
+        return old_address
 
   @Milter.noreply
   def connect(self,hostname,unused,hostaddr):
@@ -131,7 +131,7 @@ class srsMilter(Milter.Base):
     if hostaddr and len(hostaddr) > 0:
       ipaddr = hostaddr[0]
       if iniplist(ipaddr,self.conf.internal_connect):
-	self.internal_connection = True
+        self.internal_connection = True
       if iniplist(ipaddr,self.conf.trusted_relay):
         self.trusted_relay = True
     else: ipaddr = ''
@@ -219,9 +219,9 @@ class srsMilter(Milter.Base):
   def eom(self):
     for name,val,idx in self.new_headers:
       try:
-	self.addheader(name,val,idx)
+        self.addheader(name,val,idx)
       except:
-	self.addheader(name,val)	# older sendmail can't insheader
+        self.addheader(name,val)	# older sendmail can't insheader
     return Milter.CONTINUE
 
 if __name__ == "__main__":

--- a/srsmilter.py
+++ b/srsmilter.py
@@ -231,13 +231,13 @@ if __name__ == "__main__":
   config = Config(['spfmilter.cfg','/etc/mail/spfmilter.cfg'])
   miltername = config.miltername
   socketname = config.socketname
-  print """To use this with sendmail, add the following to sendmail.cf:
+  print("""To use this with sendmail, add the following to sendmail.cf:
 
 O InputMailFilters=%s
 X%s,        S=local:%s
 
 See the sendmail README for libmilter.
-sample srsmilter startup""" % (miltername,miltername,socketname)
+sample srsmilter startup""" % (miltername,miltername,socketname))
   sys.stdout.flush()
   Milter.runmilter("pysrsfilter",socketname,240)
-  print "sample srsmilter shutdown"
+  print("sample srsmilter shutdown")

--- a/testSRS.py
+++ b/testSRS.py
@@ -138,13 +138,13 @@ class SRSTestCase(unittest.TestCase):
     srsaddr = srs.forward(sender,sender)
     self.assertEqual(srsaddr,sender)
     srsaddr = srs.forward(sender,'second.com')
-    #print srsaddr
+    #print(srsaddr)
     self.assertTrue(srsaddr.startswith(SRS.SRS0TAG))
     srsaddr1 = srs.forward(srsaddr,'third.com')
-    #print srsaddr1
+    #print(srsaddr1)
     self.assertTrue(srsaddr1.startswith(SRS.SRS0TAG))
     srsaddr2 = srs.forward(srsaddr1,'fourth.com')
-    #print srsaddr2
+    #print(srsaddr2)
     self.assertTrue(srsaddr2.startswith(SRS.SRS0TAG))
     addr = srs.reverse(srsaddr2)
     self.assertEqual(srsaddr1,addr)
@@ -160,7 +160,7 @@ class SRSTestCase(unittest.TestCase):
   def sendcmd(self,*args):
     sock = socket.socket(socket.AF_UNIX,socket.SOCK_STREAM)
     sock.connect(self.sockname)
-    sock.send(' '.join(args)+'\n')
+    sock.send(b' '.join(args)+b'\n')
     res = sock.recv(128).strip()
     sock.close()
     return res
@@ -170,9 +170,9 @@ class SRSTestCase(unittest.TestCase):
     self.daemon = Daemon(socket=sockname,secret=secret)
     server = threading.Thread(target=self.run2,name='srsd')
     server.start()
-    sender = 'mouse@orig.com'
-    srsaddr = self.sendcmd('FORWARD',sender,'second.com')
-    addr = self.sendcmd('REVERSE',srsaddr)
+    sender = b'mouse@orig.com'
+    srsaddr = self.sendcmd(b'FORWARD',sender,b'second.com')
+    addr = self.sendcmd(b'REVERSE',srsaddr)
     server.join()
     self.assertEqual(sender,addr)
 

--- a/testSRS.py
+++ b/testSRS.py
@@ -63,13 +63,13 @@ class SRSTestCase(unittest.TestCase):
     srsaddr = srs.forward(sender,sender)
     self.assertEqual(srsaddr,sender)
     srsaddr = srs.forward(sender,'second.com')
-    self.failUnless(srsaddr.startswith('"'+SRS.SRS0TAG),srsaddr)
+    self.assertTrue(srsaddr.startswith('"'+SRS.SRS0TAG),srsaddr)
     srsaddr1 = srs.forward(srsaddr,'third.com')
     #print srsaddr1
-    self.failUnless(srsaddr1.startswith('"'+SRS.SRS1TAG))
+    self.assertTrue(srsaddr1.startswith('"'+SRS.SRS1TAG))
     srsaddr2 = srs.forward(srsaddr1,'fourth.com')
     #print srsaddr2
-    self.failUnless(srsaddr2.startswith('"'+SRS.SRS1TAG))
+    self.assertTrue(srsaddr2.startswith('"'+SRS.SRS1TAG))
     addr = srs.reverse(srsaddr2)
     self.assertEqual(srsaddr,addr)
     addr = srs.reverse(srsaddr1)
@@ -97,11 +97,11 @@ class SRSTestCase(unittest.TestCase):
     # FIXME: whether case smashing occurs depends on what day it is.
     sender = 'mouse@fickle1.com'
     srsaddr = srs.forward(sender,'second.com')
-    self.failUnless(srsaddr.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr.startswith(SRS.SRS0TAG))
     self.case_smashed = False
     srs.warn = self.warn
     addr = srs.reverse(srsaddr.lower())
-    self.failUnless(self.case_smashed)	# check that warn was called
+    self.assertTrue(self.case_smashed)	# check that warn was called
     self.assertEqual(sender,addr)
 
   def testReversible(self):
@@ -115,13 +115,13 @@ class SRSTestCase(unittest.TestCase):
     self.assertEqual(srsaddr,sender)
     srsaddr = srs.forward(sender,'second.com')
     #print srsaddr
-    self.failUnless(srsaddr.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr.startswith(SRS.SRS0TAG))
     srsaddr1 = srs.forward(srsaddr,'third.com')
     #print srsaddr1
-    self.failUnless(srsaddr1.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr1.startswith(SRS.SRS0TAG))
     srsaddr2 = srs.forward(srsaddr1,'fourth.com')
     #print srsaddr2
-    self.failUnless(srsaddr2.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr2.startswith(SRS.SRS0TAG))
     addr = srs.reverse(srsaddr2)
     self.assertEqual(srsaddr1,addr)
     addr = srs.reverse(srsaddr1)
@@ -139,13 +139,13 @@ class SRSTestCase(unittest.TestCase):
     self.assertEqual(srsaddr,sender)
     srsaddr = srs.forward(sender,'second.com')
     #print srsaddr
-    self.failUnless(srsaddr.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr.startswith(SRS.SRS0TAG))
     srsaddr1 = srs.forward(srsaddr,'third.com')
     #print srsaddr1
-    self.failUnless(srsaddr1.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr1.startswith(SRS.SRS0TAG))
     srsaddr2 = srs.forward(srsaddr1,'fourth.com')
     #print srsaddr2
-    self.failUnless(srsaddr2.startswith(SRS.SRS0TAG))
+    self.assertTrue(srsaddr2.startswith(SRS.SRS0TAG))
     addr = srs.reverse(srsaddr2)
     self.assertEqual(srsaddr1,addr)
     addr = srs.reverse(srsaddr1)
@@ -181,7 +181,7 @@ class SRSTestCase(unittest.TestCase):
     import srs2envtol
     orig = 'mickey<@orig.com.>'
     newaddr = envfrom2srs.forward(orig)
-    self.failUnless(newaddr.endswith('.>'))
+    self.assertTrue(newaddr.endswith('.>'))
     addr2 = srs2envtol.reverse(newaddr)
     self.assertEqual(addr2,orig)
     # check case smashing by braindead mailers
@@ -189,7 +189,7 @@ class SRSTestCase(unittest.TestCase):
     srs2envtol.srs.warn = self.warn
     addr2 = srs2envtol.reverse(newaddr.lower())
     self.assertEqual(addr2,orig)
-    self.failUnless(self.case_smashed)
+    self.assertTrue(self.case_smashed)
 
 def suite(): return unittest.makeSuite(SRSTestCase,'test')
 

--- a/testSRS.py
+++ b/testSRS.py
@@ -56,7 +56,7 @@ class SRSTestCase(unittest.TestCase):
   def testGuarded(self):
     srs = Guarded()
     self.assertRaises(AssertionError,srs.forward,
-    	'mouse@disney.com','mydomain.com')
+            'mouse@disney.com','mydomain.com')
     srs.set_secret('shhhh!')
     srs.separator = '+'
     sender = '"Blah blah"@orig.com'
@@ -107,7 +107,7 @@ class SRSTestCase(unittest.TestCase):
   def testReversible(self):
     srs = Reversible()
     self.assertRaises(AssertionError,srs.forward,
-    	'mouse@disney.com','mydomain.com')
+            'mouse@disney.com','mydomain.com')
     srs.set_secret('shhhh!')
     srs.separator = '+'
     sender = 'mouse@orig.com'
@@ -132,7 +132,7 @@ class SRSTestCase(unittest.TestCase):
   def testDB(self,database='/tmp/srstest'):
     srs = DB(database=database)
     self.assertRaises(AssertionError,srs.forward,
-    	'mouse@disney.com','mydomain.com')
+            'mouse@disney.com','mydomain.com')
     srs.set_secret('shhhh!')
     sender = 'mouse@orig.com'
     srsaddr = srs.forward(sender,sender)

--- a/testd.py
+++ b/testd.py
@@ -10,7 +10,7 @@ import sys
 
 sock = socket(AF_UNIX,SOCK_STREAM)
 sock.connect('/tmp/srsd')
-sock.send(' '.join(sys.argv[1:])+'\n')
+sock.send(b' '.join(sys.argv[1:])+b'\n')
 res = sock.recv(128).strip()
 print(res)
 sock.close()

--- a/testd.py
+++ b/testd.py
@@ -12,5 +12,5 @@ sock = socket(AF_UNIX,SOCK_STREAM)
 sock.connect('/tmp/srsd')
 sock.send(' '.join(sys.argv[1:])+'\n')
 res = sock.recv(128).strip()
-print res
+print(res)
 sock.close()


### PR DESCRIPTION
Here is a patchseries to get pysrs to be usable for python2 and python3.

But with python3 we need the API of pysrs to be more defined (where to use strings, where to 
use bytestrings). I simply made everything passing, but not put effort in thinking about the line where a user expect strings and where bytstring.