### PR TITLE
Address 'TEMP cannot use a string pattern on a bytes-like object' and make logging use syslog

### DIFF
--- a/SES/ses.py
+++ b/SES/ses.py
@@ -46,6 +46,7 @@ import hmac
 try: from hashlib import sha1 as sha
 except: import sha
 import struct
+import syslog
 
 DAY = 24*60*60	# size of day
 
@@ -130,7 +131,7 @@ class SES(object):
     return int(s / self.frac_day)
 
   def warn(self,*msg):
-    print('WARNING:',' '.join(msg), file=sys.stderr)
+     syslog.syslog('WARNING: ' + ' '.join(msg))
 
   def set_secret(self,*args):
     """ses.set_secret(new,old,...)

--- a/SocketMap.py
+++ b/SocketMap.py
@@ -58,10 +58,10 @@ class Handler(socketserver.StreamRequestHandler):
       try:
         line = self.read()
         self.log(repr(line))
-        args = line.split(b' ',1)
-        mapname = args.pop(0).decode().replace('-','_')
+        args = line.decode().split(' ',1)
+        mapname = args.pop(0).replace('-','_')
         meth = getattr(self, '_handle_' + mapname, None)
-        if not map:
+        if not meth:
           raise ValueError("Unrecognized map: %s" % mapname)
         res = meth(*args)
         self.write('OK ' + res)

--- a/pysrs.py
+++ b/pysrs.py
@@ -157,6 +157,7 @@ def main(args):
     
   daemon.server.srs = srs
   daemon.server.ses = ses
+  syslog.openlog('pysrs.py',0,syslog.LOG_MAIL)
   syslog.syslog('pysrs: started')
   sys.stdout.flush()
   daemon.run()

--- a/pysrs.py
+++ b/pysrs.py
@@ -17,15 +17,12 @@ except:
 import SocketMap
 import time
 import sys
+import syslog
 
 class SRSHandler(SocketMap.Handler):
 
   def log(self,*msg):
-    # print "%s [%d]" % (time.strftime('%Y%b%d %H:%M:%S'),self.id),
-    print("%s" % (time.strftime('%Y%b%d %H:%M:%S'),), end=' ')
-    for i in msg: print(i, end=' ')
-    print()
-    sys.stdout.flush()
+     syslog.syslog(' '.join(msg))
 
   bracketRE = re.compile(r'[<>]')
   traildotRE = re.compile(r'\.$')
@@ -37,7 +34,7 @@ class SRSHandler(SocketMap.Handler):
   #
   # We need to preprocess it some:
   def _handle_make_srs(self,old_address):
-    a = [s.decode() for s in old_address.split(b'\x9b')]
+    a = [s for s in old_address.split('\x9b')]
     if len(a) == 2:
       h,old_address = a
       self.log('h =',h)
@@ -86,7 +83,6 @@ class SRSHandler(SocketMap.Handler):
     # Munge ParseLocal recipient in the same manner as required
     # in EnvFromSMTP.
 
-    old_address = old_address.decode()
     use_address = self.bracketRE.sub('',old_address)
     use_address = self.traildotRE.sub('',use_address)
 
@@ -161,10 +157,10 @@ def main(args):
     
   daemon.server.srs = srs
   daemon.server.ses = ses
-  print("%s pysrs startup" % time.strftime('%Y%b%d %H:%M:%S'))
+  syslog.syslog('pysrs: started')
   sys.stdout.flush()
   daemon.run()
-  print("%s pysrs shutdown" % time.strftime('%Y%b%d %H:%M:%S'))
+  syslog.syslog('pysrs: shutdown')
 
 if __name__ == "__main__":
   main(sys.argv[1:])


### PR DESCRIPTION
Before this patch, reverse_srs would work but I would consistently get an error when calling make_srs:

% ./smapc unix:///tmp/pysrs make_srs 'infooo<@example.org.>'
TEMP cannot use a string pattern on a bytes-like object
% ./smapc unix:///tmp/pysrs reverse_srs 'SRS0=J6Lly=CZ=example.org=infooo<@example.com.>'
OK infooo<@example.org.>

After the patch both directions seem to work just fine:

% ./smapc unix:///tmp/pysrs make_srs 'infooo<@example.org.>'
OK SRS0=J6Lly=CZ=example.org=infooo<@example.com.>
% ./smapc unix:///tmp/pysrs reverse_srs 'SRS0=J6Lly=CZ=example.org=infooo<@example.com.>'
OK infooo<@example.org.>

To help debugging I also made the logging go to syslog rather than STDOUT.