### PR TITLE
Use python3 shebang.

### DIFF
--- a/envfrom2srs.py
+++ b/envfrom2srs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # sendmail program map for SRS
 #
 # Use only if absolutely necessary.  It is *very* inefficient and

--- a/srs2envtol.py
+++ b/srs2envtol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.3
+#!/usr/bin/env python3
 # sendmail program map for SRS
 #
 # Use only if absolutely necessary.  It is *very* inefficient and


### PR DESCRIPTION
The scripts have benn ported to Python3 so they should not ship a python2.3 shebang anymore ;)

As distributions tend to install python to different path the best way is to use the /usr/bin/env python3 as shebang.